### PR TITLE
fix(typescript): fallback to checking cjs/mjs on missing cts/mts

### DIFF
--- a/src/@types/module.d.ts
+++ b/src/@types/module.d.ts
@@ -10,5 +10,10 @@ declare global {
 
 declare module 'module' {
 	export const _extensions: NodeJS.RequireExtensions;
-	export function _resolveFilename(filename: string, module: any): string;
+	export function _resolveFilename(
+		request: string,
+		parent: any,
+		isMain: boolean,
+		options?: any,
+	): string;
 }

--- a/tests/specs/javascript/cjs.ts
+++ b/tests/specs/javascript/cjs.ts
@@ -21,6 +21,11 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 					expect(nodeProcess.stdout).toBe(`${output}\n{"default":1234}`);
 				});
 
+				test('TypeScript Import', async () => {
+					const nodeProcess = await node.import(importPath, { typescript: true });
+					expect(nodeProcess.stdout).toBe(`${output}\n{"default":1234}`);
+				});
+
 				test('Require', async () => {
 					const nodeProcess = await node.require(importPath);
 					expect(nodeProcess.stdout).toBe(`${output}\n1234`);

--- a/tests/specs/javascript/esm.ts
+++ b/tests/specs/javascript/esm.ts
@@ -21,6 +21,11 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 					expect(nodeProcess.stdout).toBe(`${output}\n{"default":1234}`);
 				});
 
+				test('TypeScript Import', async () => {
+					const nodeProcess = await node.import(importPath, { typescript: true });
+					expect(nodeProcess.stdout).toBe(`${output}\n{"default":1234}`);
+				});
+
 				test('Require', async () => {
 					const nodeProcess = await node.require(importPath);
 					expect(nodeProcess.stdout).toBe(`${output}\n{"default":1234}`);


### PR DESCRIPTION
Same as https://github.com/esbuild-kit/esm-loader/pull/5