### PR TITLE
feat: dynamic import to interop with modules using __esModule

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"test": "node --require ./dist/index.js tests/index.ts"
 	},
 	"dependencies": {
-		"@esbuild-kit/core-utils": "github:esbuild-kit/core-utils#built/transform-dynamic-import",
+		"@esbuild-kit/core-utils": "^1.1.0",
 		"get-tsconfig": "^3.0.1"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"test": "node --require ./dist/index.js tests/index.ts"
 	},
 	"dependencies": {
-		"@esbuild-kit/core-utils": "^1.0.1",
+		"@esbuild-kit/core-utils": "github:esbuild-kit/core-utils#built/transform-dynamic-import",
 		"get-tsconfig": "^3.0.1"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@esbuild-kit/core-utils': github:esbuild-kit/core-utils#built/transform-dynamic-import
+  '@esbuild-kit/core-utils': ^1.1.0
   '@pvtnbr/eslint-config': ^0.22.0
   '@types/node': ^17.0.33
   '@types/semver': ^7.3.9
@@ -15,7 +15,7 @@ specifiers:
   typescript: ^4.6.4
 
 dependencies:
-  '@esbuild-kit/core-utils': github.com/esbuild-kit/core-utils/2f331b45bfa3532dcdec19febe0049589a5e5d24
+  '@esbuild-kit/core-utils': 1.1.0
   get-tsconfig: 3.0.1
 
 devDependencies:
@@ -52,6 +52,12 @@ packages:
       chalk: 2.4.2
       js-tokens: 4.0.0
     dev: true
+
+  /@esbuild-kit/core-utils/1.1.0:
+    resolution: {integrity: sha512-BPWlYIrfxIrjV3wzHsfOOiXgDWbh3vrveB+kr/ASTctI9tLF/k6bFo9PBiHxMGlbZCyWn8Ry3aeOB15ceHeqFw==}
+    dependencies:
+      esbuild: 0.14.38
+    dev: false
 
   /@eslint/eslintrc/1.2.3:
     resolution: {integrity: sha512-uGo44hIwoLGNyduRpjdEpovcbMdd+Nv7amtmJxnKmI8xj6yd5LncmSwDa5NgX/41lIFJtkjD6YdVfgEzPfJ5UA==}
@@ -3670,11 +3676,3 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
-
-  github.com/esbuild-kit/core-utils/2f331b45bfa3532dcdec19febe0049589a5e5d24:
-    resolution: {tarball: https://codeload.github.com/esbuild-kit/core-utils/tar.gz/2f331b45bfa3532dcdec19febe0049589a5e5d24}
-    name: '@esbuild-kit/core-utils'
-    version: 0.0.0-semantic-release
-    dependencies:
-      esbuild: 0.14.38
-    dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@esbuild-kit/core-utils': ^1.0.1
+  '@esbuild-kit/core-utils': github:esbuild-kit/core-utils#built/transform-dynamic-import
   '@pvtnbr/eslint-config': ^0.22.0
   '@types/node': ^17.0.33
   '@types/semver': ^7.3.9
@@ -15,7 +15,7 @@ specifiers:
   typescript: ^4.6.4
 
 dependencies:
-  '@esbuild-kit/core-utils': 1.0.1
+  '@esbuild-kit/core-utils': github.com/esbuild-kit/core-utils/84215db24512f75faded02a446bf3ffeb2f8ff3b
   get-tsconfig: 3.0.1
 
 devDependencies:
@@ -52,12 +52,6 @@ packages:
       chalk: 2.4.2
       js-tokens: 4.0.0
     dev: true
-
-  /@esbuild-kit/core-utils/1.0.1:
-    resolution: {integrity: sha512-N9fE4afacf4+82Xygmoa5IXASoPHHPL/OF3E5OaDVWtdoi1rk3StLGV6Vl7rqFSJCetghho/O1jvU/VnMf2pLw==}
-    dependencies:
-      esbuild: 0.14.38
-    dev: false
 
   /@eslint/eslintrc/1.2.3:
     resolution: {integrity: sha512-uGo44hIwoLGNyduRpjdEpovcbMdd+Nv7amtmJxnKmI8xj6yd5LncmSwDa5NgX/41lIFJtkjD6YdVfgEzPfJ5UA==}
@@ -3676,3 +3670,11 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+  github.com/esbuild-kit/core-utils/84215db24512f75faded02a446bf3ffeb2f8ff3b:
+    resolution: {tarball: https://codeload.github.com/esbuild-kit/core-utils/tar.gz/84215db24512f75faded02a446bf3ffeb2f8ff3b}
+    name: '@esbuild-kit/core-utils'
+    version: 0.0.0-semantic-release
+    dependencies:
+      esbuild: 0.14.38
+    dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ specifiers:
   typescript: ^4.6.4
 
 dependencies:
-  '@esbuild-kit/core-utils': github.com/esbuild-kit/core-utils/50f21c0900c441b1008407de79174a67b5b7890f
+  '@esbuild-kit/core-utils': github.com/esbuild-kit/core-utils/d27f2dfa6dd454ba51c58dd6c6a3db247651b4f5
   get-tsconfig: 3.0.1
 
 devDependencies:
@@ -3671,8 +3671,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  github.com/esbuild-kit/core-utils/50f21c0900c441b1008407de79174a67b5b7890f:
-    resolution: {tarball: https://codeload.github.com/esbuild-kit/core-utils/tar.gz/50f21c0900c441b1008407de79174a67b5b7890f}
+  github.com/esbuild-kit/core-utils/d27f2dfa6dd454ba51c58dd6c6a3db247651b4f5:
+    resolution: {tarball: https://codeload.github.com/esbuild-kit/core-utils/tar.gz/d27f2dfa6dd454ba51c58dd6c6a3db247651b4f5}
     name: '@esbuild-kit/core-utils'
     version: 0.0.0-semantic-release
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ specifiers:
   typescript: ^4.6.4
 
 dependencies:
-  '@esbuild-kit/core-utils': github.com/esbuild-kit/core-utils/d27f2dfa6dd454ba51c58dd6c6a3db247651b4f5
+  '@esbuild-kit/core-utils': github.com/esbuild-kit/core-utils/2f331b45bfa3532dcdec19febe0049589a5e5d24
   get-tsconfig: 3.0.1
 
 devDependencies:
@@ -3671,8 +3671,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  github.com/esbuild-kit/core-utils/d27f2dfa6dd454ba51c58dd6c6a3db247651b4f5:
-    resolution: {tarball: https://codeload.github.com/esbuild-kit/core-utils/tar.gz/d27f2dfa6dd454ba51c58dd6c6a3db247651b4f5}
+  github.com/esbuild-kit/core-utils/2f331b45bfa3532dcdec19febe0049589a5e5d24:
+    resolution: {tarball: https://codeload.github.com/esbuild-kit/core-utils/tar.gz/2f331b45bfa3532dcdec19febe0049589a5e5d24}
     name: '@esbuild-kit/core-utils'
     version: 0.0.0-semantic-release
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ specifiers:
   typescript: ^4.6.4
 
 dependencies:
-  '@esbuild-kit/core-utils': github.com/esbuild-kit/core-utils/84215db24512f75faded02a446bf3ffeb2f8ff3b
+  '@esbuild-kit/core-utils': github.com/esbuild-kit/core-utils/50f21c0900c441b1008407de79174a67b5b7890f
   get-tsconfig: 3.0.1
 
 devDependencies:
@@ -3671,8 +3671,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  github.com/esbuild-kit/core-utils/84215db24512f75faded02a446bf3ffeb2f8ff3b:
-    resolution: {tarball: https://codeload.github.com/esbuild-kit/core-utils/tar.gz/84215db24512f75faded02a446bf3ffeb2f8ff3b}
+  github.com/esbuild-kit/core-utils/50f21c0900c441b1008407de79174a67b5b7890f:
+    resolution: {tarball: https://codeload.github.com/esbuild-kit/core-utils/tar.gz/50f21c0900c441b1008407de79174a67b5b7890f}
     name: '@esbuild-kit/core-utils'
     version: 0.0.0-semantic-release
     dependencies:

--- a/tests/fixtures/import-file.cjs
+++ b/tests/fixtures/import-file.cjs
@@ -1,0 +1,1 @@
+import(process.argv[2]).then(m => console.log(JSON.stringify(m)));

--- a/tests/fixtures/lib/cjs-ext-cjs/index.cjs
+++ b/tests/fixtures/lib/cjs-ext-cjs/index.cjs
@@ -3,7 +3,8 @@ const fs = require('node:fs');
 console.log(
 	'loaded cjs-ext-cjs/index.cjs',
 	Boolean(fs),
-	/:6:16/.test((new Error()).stack),
+	Boolean(import('fs')),
+	/:7:16/.test((new Error()).stack),
 );
 
 module.exports = 1234;

--- a/tests/fixtures/lib/cjs-ext-js/index.js
+++ b/tests/fixtures/lib/cjs-ext-js/index.js
@@ -3,7 +3,8 @@ const fs = require('node:fs');
 console.log(
 	'loaded cjs-ext-js/index.js',
 	Boolean(fs),
-	/:6:16/.test((new Error()).stack),
+	Boolean(import('fs')),
+	/:7:16/.test((new Error()).stack),
 );
 
 module.exports = 1234;

--- a/tests/fixtures/lib/esm-ext-js/index.js
+++ b/tests/fixtures/lib/esm-ext-js/index.js
@@ -3,7 +3,8 @@ import fs from 'node:fs';
 console.log(
 	'loaded esm-ext-js/index.js',
 	Boolean(fs),
-	/:6:16/.test((new Error()).stack),
+	Boolean(import('fs')),
+	/:7:16/.test((new Error()).stack),
 );
 
 export default 1234;

--- a/tests/fixtures/lib/esm-ext-mjs/index.mjs
+++ b/tests/fixtures/lib/esm-ext-mjs/index.mjs
@@ -3,7 +3,8 @@ import fs from 'node:fs';
 console.log(
 	'loaded esm-ext-mjs/index.mjs',
 	Boolean(fs),
-	/:6:16/.test((new Error()).stack),
+	Boolean(import('fs')),
+	/:7:16/.test((new Error()).stack),
 );
 
 export default 1234;

--- a/tests/fixtures/lib/ts-ext-cts/index.cts
+++ b/tests/fixtures/lib/ts-ext-cts/index.cts
@@ -3,7 +3,8 @@ import fs from 'node:fs';
 console.log(
 	'loaded ts-ext-cts/index.cts',
 	Boolean(fs),
-	/:6:16/.test((new Error()).stack),
+	Boolean(import('fs')),
+	/:7:16/.test((new Error()).stack),
 );
 
 function valueNumber(value: number) {

--- a/tests/fixtures/lib/ts-ext-jsx/index.jsx
+++ b/tests/fixtures/lib/ts-ext-jsx/index.jsx
@@ -3,7 +3,8 @@ import fs from 'node:fs';
 console.log(
 	'loaded ts-ext-jsx/index.jsx',
 	Boolean(fs),
-	/:6:16/.test((new Error()).stack),
+	Boolean(import('fs')),
+	/:7:16/.test((new Error()).stack),
 );
 
 const React = {

--- a/tests/fixtures/lib/ts-ext-mts/index.mts
+++ b/tests/fixtures/lib/ts-ext-mts/index.mts
@@ -3,7 +3,8 @@ import fs from 'node:fs';
 console.log(
 	'loaded ts-ext-mts/index.mts',
 	Boolean(fs),
-	/:6:16/.test((new Error()).stack),
+	Boolean(import('fs')),
+	/:7:16/.test((new Error()).stack),
 );
 
 function valueNumber(value: number) {

--- a/tests/fixtures/lib/ts-ext-ts/index.ts
+++ b/tests/fixtures/lib/ts-ext-ts/index.ts
@@ -3,7 +3,8 @@ import fs from 'node:fs';
 console.log(
 	'loaded ts-ext-ts/index.ts',
 	Boolean(fs),
-	/:6:16/.test((new Error()).stack),
+	Boolean(import('fs')),
+	/:7:16/.test((new Error()).stack),
 );
 
 function valueNumber(value: number) {

--- a/tests/fixtures/lib/ts-ext-tsx/index.tsx
+++ b/tests/fixtures/lib/ts-ext-tsx/index.tsx
@@ -3,7 +3,8 @@ import fs from 'node:fs';
 console.log(
 	'loaded ts-ext-tsx/index.tsx',
 	Boolean(fs),
-	/:6:16/.test((new Error()).stack),
+	Boolean(import('fs')),
+	/:7:16/.test((new Error()).stack),
 );
 
 const React = {

--- a/tests/specs/javascript/cjs.ts
+++ b/tests/specs/javascript/cjs.ts
@@ -22,7 +22,7 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 				});
 
 				test('TypeScript Import', async () => {
-					const nodeProcess = await node.import(importPath, { typescript: true });
+					const nodeProcess = await node.import(importPath, { mode: 'typescript' });
 					expect(nodeProcess.stdout).toBe(`${output}\n{"default":1234}`);
 				});
 

--- a/tests/specs/javascript/cjs.ts
+++ b/tests/specs/javascript/cjs.ts
@@ -6,7 +6,7 @@ import { nodeSupportsImport } from '../../utils/node-supports-import';
 export default testSuite(async ({ describe }, node: NodeApis) => {
 	describe('Load CJS', ({ describe }) => {
 		describe('.cjs extension', ({ describe }) => {
-			const output = 'loaded cjs-ext-cjs/index.cjs true true';
+			const output = 'loaded cjs-ext-cjs/index.cjs true true true';
 
 			describe('full path', ({ test }) => {
 				const importPath = './lib/cjs-ext-cjs/index.cjs';
@@ -77,7 +77,7 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 		});
 
 		describe('.js extension', ({ describe }) => {
-			const output = 'loaded cjs-ext-js/index.js true true';
+			const output = 'loaded cjs-ext-js/index.js true true true';
 
 			describe('full path', ({ test }) => {
 				const importPath = './lib/cjs-ext-js/index.js';

--- a/tests/specs/javascript/esm.ts
+++ b/tests/specs/javascript/esm.ts
@@ -6,7 +6,7 @@ import { nodeSupportsImport } from '../../utils/node-supports-import';
 export default testSuite(async ({ describe }, node: NodeApis) => {
 	describe('Load ESM', ({ describe }) => {
 		describe('.mjs extension', ({ describe }) => {
-			const output = 'loaded esm-ext-mjs/index.mjs true true';
+			const output = 'loaded esm-ext-mjs/index.mjs true true true';
 
 			describe('full path', ({ test }) => {
 				const importPath = './lib/esm-ext-mjs/index.mjs';
@@ -77,7 +77,7 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 		});
 
 		describe('.js extension', ({ describe }) => {
-			const output = 'loaded esm-ext-js/index.js true true';
+			const output = 'loaded esm-ext-js/index.js true true true';
 
 			describe('full path', ({ test }) => {
 				const importPath = './lib/esm-ext-js/index.js';

--- a/tests/specs/javascript/esm.ts
+++ b/tests/specs/javascript/esm.ts
@@ -22,7 +22,7 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 				});
 
 				test('TypeScript Import', async () => {
-					const nodeProcess = await node.import(importPath, { typescript: true });
+					const nodeProcess = await node.import(importPath, { mode: 'typescript' });
 					expect(nodeProcess.stdout).toBe(`${output}\n{"default":1234}`);
 				});
 
@@ -89,12 +89,12 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 
 				test('Import', async () => {
 					const nodeProcess = await node.import(importPath);
+					expect(nodeProcess.stdout).toBe(`${output}\n{"default":1234}`);
+				});
 
-					if (semver.satisfies(node.version, nodeSupportsImport)) {
-						expect(nodeProcess.stdout).toBe(`${output}\n{"default":{"default":1234}}`);
-					} else {
-						expect(nodeProcess.stdout).toBe(`${output}\n{"default":1234}`);
-					}
+				test('CommonJS Import', async () => {
+					const nodeProcess = await node.import(importPath, { mode: 'commonjs' });
+					expect(nodeProcess.stdout).toBe(`${output}\n{"default":1234}`);
 				});
 
 				test('Require', async () => {

--- a/tests/specs/typescript/cts.ts
+++ b/tests/specs/typescript/cts.ts
@@ -5,7 +5,7 @@ import { nodeSupportsImport } from '../../utils/node-supports-import';
 
 export default testSuite(async ({ describe }, node: NodeApis) => {
 	describe('.cts extension', ({ describe }) => {
-		const output = 'loaded ts-ext-cts/index.cts true true';
+		const output = 'loaded ts-ext-cts/index.cts true true true';
 
 		describe('full path', ({ test }) => {
 			const importPath = './lib/ts-ext-cts/index.cts';

--- a/tests/specs/typescript/cts.ts
+++ b/tests/specs/typescript/cts.ts
@@ -40,7 +40,7 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			});
 
 			test('Import', async () => {
-				const nodeProcess = await node.import(importPath, { 'mode': 'typescript' });
+				const nodeProcess = await node.import(importPath, { mode: 'typescript' });
 
 				if (semver.satisfies(node.version, nodeSupportsImport)) {
 					expect(nodeProcess.stderr).toMatch('Cannot find module');

--- a/tests/specs/typescript/cts.ts
+++ b/tests/specs/typescript/cts.ts
@@ -40,7 +40,7 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			});
 
 			test('Import', async () => {
-				const nodeProcess = await node.import(importPath, { typescript: true });
+				const nodeProcess = await node.import(importPath, { 'mode': 'typescript' });
 
 				if (semver.satisfies(node.version, nodeSupportsImport)) {
 					expect(nodeProcess.stderr).toMatch('Cannot find module');

--- a/tests/specs/typescript/jsx.ts
+++ b/tests/specs/typescript/jsx.ts
@@ -5,7 +5,7 @@ import { nodeSupportsImport } from '../../utils/node-supports-import';
 
 export default testSuite(async ({ describe }, node: NodeApis) => {
 	describe('.jsx extension', ({ describe }) => {
-		const output = 'loaded ts-ext-jsx/index.jsx true true';
+		const output = 'loaded ts-ext-jsx/index.jsx true true true';
 
 		describe('full path', ({ test }) => {
 			const importPath = './lib/ts-ext-jsx/index.jsx';

--- a/tests/specs/typescript/mts.ts
+++ b/tests/specs/typescript/mts.ts
@@ -5,7 +5,7 @@ import { nodeSupportsImport } from '../../utils/node-supports-import';
 
 export default testSuite(async ({ describe }, node: NodeApis) => {
 	describe('.mts extension', ({ describe }) => {
-		const output = 'loaded ts-ext-mts/index.mts true true';
+		const output = 'loaded ts-ext-mts/index.mts true true true';
 
 		describe('full path', ({ test }) => {
 			const importPath = './lib/ts-ext-mts/index.mts';

--- a/tests/specs/typescript/mts.ts
+++ b/tests/specs/typescript/mts.ts
@@ -40,7 +40,7 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			});
 
 			test('Import', async () => {
-				const nodeProcess = await node.import(importPath, { typescript: true });
+				const nodeProcess = await node.import(importPath, { mode: 'typescript' });
 
 				if (semver.satisfies(node.version, nodeSupportsImport)) {
 					expect(nodeProcess.stderr).toMatch('Cannot find module');

--- a/tests/specs/typescript/ts.ts
+++ b/tests/specs/typescript/ts.ts
@@ -5,7 +5,7 @@ import { nodeSupportsImport } from '../../utils/node-supports-import';
 
 export default testSuite(async ({ describe }, node: NodeApis) => {
 	describe('.ts extension', ({ describe }) => {
-		const output = 'loaded ts-ext-ts/index.ts true true';
+		const output = 'loaded ts-ext-ts/index.ts true true true';
 
 		describe('full path', ({ test }) => {
 			const importPath = './lib/ts-ext-ts/index.ts';

--- a/tests/specs/typescript/tsx.ts
+++ b/tests/specs/typescript/tsx.ts
@@ -5,7 +5,7 @@ import { nodeSupportsImport } from '../../utils/node-supports-import';
 
 export default testSuite(async ({ describe }, node: NodeApis) => {
 	describe('.tsx extension', ({ describe }) => {
-		const output = 'loaded ts-ext-tsx/index.tsx true true';
+		const output = 'loaded ts-ext-tsx/index.tsx true true true';
 
 		describe('full path', ({ test }) => {
 			const importPath = './lib/ts-ext-tsx/index.tsx';

--- a/tests/utils/node-with-loader.ts
+++ b/tests/utils/node-with-loader.ts
@@ -52,12 +52,21 @@ export async function createNode(
 		import(
 			filePath: string,
 			options?: {
-				typescript?: boolean;
+				mode?: 'commonjs' | 'typescript';
 			},
 		) {
+			let extension = 'js';
+
+			const mode = options?.mode;
+			if (mode === 'typescript') {
+				extension = 'ts';
+			} else if (mode === 'commonjs') {
+				extension = 'cjs';
+			}
+
 			return nodeWithLoader({
 				args: [
-					`./import-file${options?.typescript ? '.ts' : '.js'}`,
+					`./import-file.${extension}`,
 					filePath,
 				],
 				nodePath: node.path,


### PR DESCRIPTION
## Problem
Dynamically importing an ESM `.js` file resulting in getting wrapped in `{"default": ... }`.

Importing the following would look like this:

```js
export default 1234
```

```json
{"default":{"default":1234}}
```

## Changes
- New core-utils transforms dynamic imports to interop with transformed modules. Although this is a feature, it's also a breaking change.