### PR TITLE
resolve js -> ts also for path alias

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -170,7 +170,7 @@ Module._resolveFilename = function (request, parent, isMain, options) {
  * Typescript gives .ts, .cts, or .mts priority over actual .js, .cjs, or .mjs extensions
  */
 function resolveTsFilename(
-	this:ThisType<typeof resolveFilename>,
+	this: ThisType<typeof resolveFilename>,
 	request: string,
 	parent: any,
 	isMain: boolean,


### PR DESCRIPTION
I noticed that tsx correctly resolves to `.ts` files when the import ends with `.js`. But it does not work if the file is behind a TypeScript path alias.

This demonstrates the problem:
https://stackblitz.com/edit/node-uvmbub?file=index.ts

The proposed change works well in my project. If you agree, I can also make a corresponding PR for esm-loader