### PR TITLE
Work with ts-node instead of causing a TypeError

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -108,13 +108,19 @@ const extensions = Module._extensions;
  * rather than ".cjs" (it might as well be ".random-ext")
  */
 Object.defineProperty(extensions, '.mjs', {
-	value: transformer,
+	get() {
+		return transformer;
+	},
 
 	// Prevent Object.keys from detecting these extensions
 	// when CJS loader iterates over the possible extensions
 	enumerable: false,
-	// Prevents breaking interoperability with ts-node, which may need to overwrite this.
-	writable: true
+	// Similar libraries like ts-node and esbuild-register may attempt override this as well.
+	// this empty setter is to prevent the error from being thrown:
+	// TypeError: Cannot assign to read only property '.mjs' of object '[object Object]'
+	set() {
+		// no-op
+	},
 });
 
 const supportsNodePrefix = (

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,6 +113,8 @@ Object.defineProperty(extensions, '.mjs', {
 	// Prevent Object.keys from detecting these extensions
 	// when CJS loader iterates over the possible extensions
 	enumerable: false,
+	// Prevents breaking interoperability with ts-node, which may need to overwrite this.
+	writable: true
 });
 
 const supportsNodePrefix = (

--- a/tests/specs/javascript/esm.ts
+++ b/tests/specs/javascript/esm.ts
@@ -1,4 +1,5 @@
 import { testSuite, expect } from 'manten';
+import Module from 'module';
 import semver from 'semver';
 import type { NodeApis } from '../../utils/node-with-loader';
 import nodeSupports from '../../utils/node-supports';
@@ -30,6 +31,15 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 
 			describe('full path', ({ test }) => {
 				const importPath = './lib/esm-ext-mjs/index.mjs';
+
+				test('Does not throw error when overwritten', async () => {
+					const extensions = Module._extensions;
+					extensions['.mjs'] = () => {
+						throw new Error('Overwritten');
+					};
+					const nodeProcess = await node.load(importPath);
+					assertResults(nodeProcess.stdout, !nodeSupportsEsm);
+				});
 
 				test('Load', async () => {
 					const nodeProcess = await node.load(importPath);


### PR DESCRIPTION
Prevents the following error thrown when projects like `ts-node` *also* try to register `.mjs`.

`TypeError: Cannot assign to read only property '.mjs' of object '[object Object]'` w

This can happen in dependencies like [cosmic-config](https://github.com/Codex-/cosmiconfig-typescript-loader/blob/main/lib/loader.ts) that use `ts-node` because they don't know that `tsx` is already loaded.