### PR TITLE
Only transform files that need to be transformed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,9 +67,9 @@ function transformer(
 		}
 	} else if (
 		// Best guesses for files that need to be transformed.
-		t.includes('{export ') ||
-		t.includes('{import ') ||
-		t.split('\n').some((line) => line.startsWith('import ') || line.startsWith('export '))
+		code.includes('{export ') ||
+		code.includes('{import ') ||
+		code.split('\n').some((line) => line.startsWith('import ') || line.startsWith('export '))
 	)
 		const transformed = transformSync(
 			code,

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,12 @@ function transformer(
 		if (transformed) {
 			code = applySourceMap(transformed, filePath);
 		}
-	} else {
+	} else if (
+		// Best guesses for files that need to be transformed.
+		t.includes('{export ') ||
+		t.includes('{import ') ||
+		t.split('\n').some((line) => line.startsWith('import ') || line.startsWith('export '))
+	)
 		const transformed = transformSync(
 			code,
 			filePath,

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ function transformer(
 
 	let code = fs.readFileSync(filePath, 'utf8');
 
-	const hasImportOrExport = /^\s*(?:import|export)/gm;
+	const hasImportOrExport = /^\s*(?:import|export)\s/gm;
 
 	if (filePath.endsWith('.cjs') && nodeSupportsImport) {
 		const transformed = transformDynamicImport(filePath, code);
@@ -69,11 +69,9 @@ function transformer(
 		}
 	} else if (
 		// Best guesses for files that need to be transformed.
-		!filePath.endsWith('.js')
-		|| code.includes('{export ')
-		|| code.includes('{import ')
-		|| code.includes('import(')
-		|| hasImportOrExport.test(code)
+		!filePath.endsWith('.js') // not .js, so possibly ts, tsx, mjs, mts etc.
+		|| code.includes('import(') // dynamic import
+		|| hasImportOrExport.test(code) // any line starts with import or export
 	) {
 		const transformed = transformSync(
 			code,


### PR DESCRIPTION
This fixes a ton of weird bugs we are having, such as `__name not defined` in our webpack bundle, and made our code run much faster, while still working with ESM modules.
